### PR TITLE
templates/mdl-dark/main.html: Move repetition to mdl-card instead of new columns

### DIFF
--- a/templates/mdl-dark/main.html
+++ b/templates/mdl-dark/main.html
@@ -18,8 +18,8 @@
 			<div class="ribbon mdl-color--primary"></div>
 			<main class="mdl-layout__content">
 				<div class="mdl-grid">
-					<%& table.reverseOrderedPairs(modtimes_r) %>
 					<div class="mdl-cell mdl-cell--8-col">
+						<%& table.reverseOrderedPairs(modtimes_r) %>
 						<div class="mdl-card mdl-shadow--2dp mdl-color-text--grey-300 mdl-color--grey-800">
 							<div class="mdl-card__title mdl-color-text--grey-300">
 								<h3 class="mdl-card__title-text"><%= posts_title[v] %></h3>
@@ -36,8 +36,8 @@
 								<a class="mdl-button mdl-button--accent mdl-js-button mdl-js-ripple-effect" href="/post/<%= v %>">View Post</a>
 							</div>
 						</div>
+						<%&%>
 					</div>
-					<%&%>
 					<div class="mdl-cell mdl-cell--4-col">
 						<div class="mdl-card mdl-shadow--2dp mdl-color--grey-800">
 							<div class="mdl-card__title mdl-color-text--grey-300">


### PR DESCRIPTION
Adding in new columns means the content gets pushed down which is why the --4-col about section was at the bottom of the page.
